### PR TITLE
Send only hash announcement for blob transaction type

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionBroadcaster.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionBroadcaster.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.transactions;
 
 import static org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.toTransactionList;
+import static org.hyperledger.besu.plugin.data.TransactionType.BLOB_TX_TYPE;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
 
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -23,11 +24,16 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.messages.EthPV65;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool.TransactionBatchAddedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
+import org.hyperledger.besu.plugin.data.TransactionType;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,12 +41,17 @@ import org.slf4j.LoggerFactory;
 public class TransactionBroadcaster implements TransactionBatchAddedListener {
   private static final Logger LOG = LoggerFactory.getLogger(TransactionBroadcaster.class);
 
+  private static final EnumSet<TransactionType> ANNOUNCE_HASH_ONLY_TX_TYPES =
+      EnumSet.of(BLOB_TX_TYPE);
+
+  private static final Boolean HASH_ONLY_BROADCAST = Boolean.TRUE;
+  private static final Boolean FULL_BROADCAST = Boolean.FALSE;
+
   private final AbstractPendingTransactionsSorter pendingTransactions;
   private final PeerTransactionTracker transactionTracker;
   private final TransactionsMessageSender transactionsMessageSender;
   private final NewPooledTransactionHashesMessageSender newPooledTransactionHashesMessageSender;
   private final EthContext ethContext;
-  private final int numPeersToSendFullTransactions;
 
   public TransactionBroadcaster(
       final EthContext ethContext,
@@ -53,8 +64,6 @@ public class TransactionBroadcaster implements TransactionBatchAddedListener {
     this.transactionsMessageSender = transactionsMessageSender;
     this.newPooledTransactionHashesMessageSender = newPooledTransactionHashesMessageSender;
     this.ethContext = ethContext;
-    this.numPeersToSendFullTransactions =
-        (int) Math.ceil(Math.sqrt(ethContext.getEthPeers().getMaxPeers()));
   }
 
   public void relayTransactionPoolTo(final EthPeer peer) {
@@ -70,14 +79,23 @@ public class TransactionBroadcaster implements TransactionBatchAddedListener {
   }
 
   @Override
-  public void onTransactionsAdded(final Iterable<Transaction> transactions) {
+  public void onTransactionsAdded(final Collection<Transaction> transactions) {
     final int currPeerCount = ethContext.getEthPeers().peerCount();
     if (currPeerCount == 0) {
       return;
     }
 
-    List<EthPeer> peersWithOnlyTransactionSupport = new ArrayList<>(currPeerCount);
-    List<EthPeer> peersWithTransactionHashesSupport = new ArrayList<>(currPeerCount);
+    final int numPeersToSendFullTransactions = (int) Math.ceil(Math.sqrt(currPeerCount));
+
+    final Map<Boolean, List<Transaction>> transactionByBroadcastMode =
+        transactions.stream()
+            .collect(
+                Collectors.partitioningBy(
+                    tx -> ANNOUNCE_HASH_ONLY_TX_TYPES.contains(tx.getType())));
+
+    final List<EthPeer> sendOnlyFullTransactionPeers = new ArrayList<>(currPeerCount);
+    final List<EthPeer> sendOnlyHashPeers = new ArrayList<>(currPeerCount);
+    final List<EthPeer> sendMixedPeers = new ArrayList<>(currPeerCount);
 
     ethContext
         .getEthPeers()
@@ -85,65 +103,94 @@ public class TransactionBroadcaster implements TransactionBatchAddedListener {
         .forEach(
             peer -> {
               if (peer.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES)) {
-                peersWithTransactionHashesSupport.add(peer);
+                sendOnlyHashPeers.add(peer);
               } else {
-                peersWithOnlyTransactionSupport.add(peer);
+                sendOnlyFullTransactionPeers.add(peer);
               }
             });
 
-    if (peersWithOnlyTransactionSupport.size() < numPeersToSendFullTransactions) {
+    if (sendOnlyFullTransactionPeers.size() < numPeersToSendFullTransactions) {
       final int delta =
           Math.min(
-              numPeersToSendFullTransactions - peersWithOnlyTransactionSupport.size(),
-              peersWithTransactionHashesSupport.size());
+              numPeersToSendFullTransactions - sendOnlyFullTransactionPeers.size(),
+              sendOnlyHashPeers.size());
 
-      Collections.shuffle(peersWithTransactionHashesSupport);
+      Collections.shuffle(sendOnlyHashPeers);
 
-      // move peers from the other list to reach the required size for full transaction peers
-      movePeersBetweenLists(
-          peersWithTransactionHashesSupport, peersWithOnlyTransactionSupport, delta);
+      // move peers from the mixed list to reach the required size for full transaction peers
+      movePeersBetweenLists(sendOnlyHashPeers, sendMixedPeers, delta);
     }
 
     traceLambda(
         LOG,
-        "Sending full transactions to {} peers and transaction hashes to {} peers."
-            + " Peers w/o eth/66 {}, peers with eth/66 {}",
-        peersWithOnlyTransactionSupport::size,
-        peersWithTransactionHashesSupport::size,
-        peersWithOnlyTransactionSupport::toString,
-        peersWithTransactionHashesSupport::toString);
+        "Sending full transactions to {} peers, transaction hashes only to {} peers and mixed to {} peers."
+            + " Peers w/o eth/65 {}, peers with eth/65 {}",
+        sendOnlyFullTransactionPeers::size,
+        sendOnlyHashPeers::size,
+        sendMixedPeers::size,
+        sendOnlyFullTransactionPeers::toString,
+        () -> sendOnlyHashPeers.toString() + sendMixedPeers.toString());
 
-    sendFullTransactions(transactions, peersWithOnlyTransactionSupport);
+    sendToFullTransactionsPeers(
+        transactionByBroadcastMode.get(FULL_BROADCAST), sendOnlyFullTransactionPeers);
 
-    sendTransactionHashes(transactions, peersWithTransactionHashesSupport);
+    sendToOnlyHashPeers(transactionByBroadcastMode, sendOnlyHashPeers);
+
+    sendToMixedPeers(transactionByBroadcastMode, sendMixedPeers);
+  }
+
+  private void sendToFullTransactionsPeers(
+      final List<Transaction> fullBroadcastTransactions, final List<EthPeer> fullTransactionPeers) {
+    sendFullTransactions(fullBroadcastTransactions, fullTransactionPeers);
+  }
+
+  private void sendToOnlyHashPeers(
+      final Map<Boolean, List<Transaction>> txsByHashOnlyBroadcast,
+      final List<EthPeer> hashOnlyPeers) {
+    final List<Transaction> allTransactions =
+        txsByHashOnlyBroadcast.values().stream().flatMap(List::stream).collect(Collectors.toList());
+
+    sendTransactionHashes(allTransactions, hashOnlyPeers);
+  }
+
+  private void sendToMixedPeers(
+      final Map<Boolean, List<Transaction>> txsByHashOnlyBroadcast,
+      final List<EthPeer> mixedPeers) {
+    sendFullTransactions(txsByHashOnlyBroadcast.get(FULL_BROADCAST), mixedPeers);
+    sendTransactionHashes(txsByHashOnlyBroadcast.get(HASH_ONLY_BROADCAST), mixedPeers);
   }
 
   private void sendFullTransactions(
-      final Iterable<Transaction> transactions, final List<EthPeer> fullTransactionPeers) {
-    fullTransactionPeers.forEach(
-        peer -> {
-          transactions.forEach(
-              transaction -> transactionTracker.addToPeerSendQueue(peer, transaction));
-          ethContext
-              .getScheduler()
-              .scheduleSyncWorkerTask(() -> transactionsMessageSender.sendTransactionsToPeer(peer));
-        });
+      final List<Transaction> transactions, final List<EthPeer> fullTransactionPeers) {
+    if (!transactions.isEmpty()) {
+      fullTransactionPeers.forEach(
+          peer -> {
+            transactions.forEach(
+                transaction -> transactionTracker.addToPeerSendQueue(peer, transaction));
+            ethContext
+                .getScheduler()
+                .scheduleSyncWorkerTask(
+                    () -> transactionsMessageSender.sendTransactionsToPeer(peer));
+          });
+    }
   }
 
   private void sendTransactionHashes(
-      final Iterable<Transaction> transactions, final List<EthPeer> transactionHashPeers) {
-    transactionHashPeers.stream()
-        .forEach(
-            peer -> {
-              transactions.forEach(
-                  transaction -> transactionTracker.addToPeerSendQueue(peer, transaction));
-              ethContext
-                  .getScheduler()
-                  .scheduleSyncWorkerTask(
-                      () ->
-                          newPooledTransactionHashesMessageSender.sendTransactionHashesToPeer(
-                              peer));
-            });
+      final List<Transaction> transactions, final List<EthPeer> transactionHashPeers) {
+    if (!transactions.isEmpty()) {
+      transactionHashPeers.stream()
+          .forEach(
+              peer -> {
+                transactions.forEach(
+                    transaction -> transactionTracker.addToPeerSendQueue(peer, transaction));
+                ethContext
+                    .getScheduler()
+                    .scheduleSyncWorkerTask(
+                        () ->
+                            newPooledTransactionHashesMessageSender.sendTransactionHashesToPeer(
+                                peer));
+              });
+    }
   }
 
   private void movePeersBetweenLists(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionBroadcasterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionBroadcasterTest.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.messages.EthPV65;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
+import org.hyperledger.besu.plugin.data.TransactionType;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -61,11 +62,11 @@ public class TransactionBroadcasterTest {
   @Mock private TransactionsMessageSender transactionsMessageSender;
   @Mock private NewPooledTransactionHashesMessageSender newPooledTransactionHashesMessageSender;
 
-  private final EthPeer ethPeerNoEth66 = mock(EthPeer.class);
-  private final EthPeer ethPeerWithEth66 = mock(EthPeer.class);
-  private final EthPeer ethPeerNoEth66_2 = mock(EthPeer.class);
-  private final EthPeer ethPeerWithEth66_2 = mock(EthPeer.class);
-  private final EthPeer ethPeerWithEth66_3 = mock(EthPeer.class);
+  private final EthPeer ethPeerNoEth65 = mock(EthPeer.class);
+  private final EthPeer ethPeerWithEth65 = mock(EthPeer.class);
+  private final EthPeer ethPeerNoEth65_2 = mock(EthPeer.class);
+  private final EthPeer ethPeerWithEth65_2 = mock(EthPeer.class);
+  private final EthPeer ethPeerWithEth65_3 = mock(EthPeer.class);
   private final BlockDataGenerator generator = new BlockDataGenerator();
 
   private TransactionBroadcaster txBroadcaster;
@@ -73,21 +74,19 @@ public class TransactionBroadcasterTest {
 
   @Before
   public void setUp() {
-    when(ethPeerNoEth66.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
+    when(ethPeerNoEth65.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
         .thenReturn(Boolean.FALSE);
-    when(ethPeerNoEth66_2.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
+    when(ethPeerNoEth65_2.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
         .thenReturn(Boolean.FALSE);
-    when(ethPeerWithEth66.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
+    when(ethPeerWithEth65.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
         .thenReturn(Boolean.TRUE);
-    when(ethPeerWithEth66_2.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
+    when(ethPeerWithEth65_2.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
         .thenReturn(Boolean.TRUE);
-    when(ethPeerWithEth66_3.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
+    when(ethPeerWithEth65_3.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES))
         .thenReturn(Boolean.TRUE);
 
     sendTaskCapture = ArgumentCaptor.forClass(Runnable.class);
     doNothing().when(ethScheduler).scheduleSyncWorkerTask(sendTaskCapture.capture());
-
-    when(ethPeers.getMaxPeers()).thenReturn(4);
 
     when(ethContext.getEthPeers()).thenReturn(ethPeers);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
@@ -105,37 +104,37 @@ public class TransactionBroadcasterTest {
   public void doNotRelayTransactionsWhenPoolIsEmpty() {
     setupTransactionPool(0, 0);
 
-    txBroadcaster.relayTransactionPoolTo(ethPeerNoEth66);
-    txBroadcaster.relayTransactionPoolTo(ethPeerWithEth66);
+    txBroadcaster.relayTransactionPoolTo(ethPeerNoEth65);
+    txBroadcaster.relayTransactionPoolTo(ethPeerWithEth65);
 
     verifyNothingSent();
   }
 
   @Test
-  public void relayFullTransactionsFromPoolWhenPeerDoesNotSupportEth66() {
+  public void relayFullTransactionsFromPoolWhenPeerDoesNotSupportEth65() {
     List<Transaction> txs = toTransactionList(setupTransactionPool(1, 1));
 
-    txBroadcaster.relayTransactionPoolTo(ethPeerNoEth66);
+    txBroadcaster.relayTransactionPoolTo(ethPeerNoEth65);
 
-    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth66, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth65, txs);
 
     sendTaskCapture.getValue().run();
 
-    verify(transactionsMessageSender).sendTransactionsToPeer(ethPeerNoEth66);
+    verify(transactionsMessageSender).sendTransactionsToPeer(ethPeerNoEth65);
     verifyNoInteractions(newPooledTransactionHashesMessageSender);
   }
 
   @Test
-  public void relayTransactionHashesFromPoolWhenPeerSupportEth66() {
+  public void relayTransactionHashesFromPoolWhenPeerSupportEth65() {
     List<Transaction> txs = toTransactionList(setupTransactionPool(1, 1));
 
-    txBroadcaster.relayTransactionPoolTo(ethPeerWithEth66);
+    txBroadcaster.relayTransactionPoolTo(ethPeerWithEth65);
 
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65, txs);
 
     sendTaskCapture.getValue().run();
 
-    verify(newPooledTransactionHashesMessageSender).sendTransactionHashesToPeer(ethPeerWithEth66);
+    verify(newPooledTransactionHashesMessageSender).sendTransactionHashesToPeer(ethPeerWithEth65);
     verifyNoInteractions(transactionsMessageSender);
   }
 
@@ -149,36 +148,36 @@ public class TransactionBroadcasterTest {
   }
 
   @Test
-  public void onTransactionsAddedWithOnlyNonEth66PeersSendFullTransactions() {
+  public void onTransactionsAddedWithOnlyNonEth65PeersSendFullTransactions() {
     when(ethPeers.peerCount()).thenReturn(2);
-    when(ethPeers.streamAvailablePeers()).thenReturn(Stream.of(ethPeerNoEth66, ethPeerNoEth66_2));
+    when(ethPeers.streamAvailablePeers()).thenReturn(Stream.of(ethPeerNoEth65, ethPeerNoEth65_2));
 
     List<Transaction> txs = toTransactionList(setupTransactionPool(1, 1));
 
     txBroadcaster.onTransactionsAdded(txs);
 
-    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth66, txs);
-    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth66_2, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth65, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth65_2, txs);
 
     sendTaskCapture.getAllValues().forEach(Runnable::run);
 
-    verify(transactionsMessageSender).sendTransactionsToPeer(ethPeerNoEth66);
-    verify(transactionsMessageSender).sendTransactionsToPeer(ethPeerNoEth66_2);
+    verify(transactionsMessageSender).sendTransactionsToPeer(ethPeerNoEth65);
+    verify(transactionsMessageSender).sendTransactionsToPeer(ethPeerNoEth65_2);
     verifyNoInteractions(newPooledTransactionHashesMessageSender);
   }
 
   @Test
-  public void onTransactionsAddedWithOnlyFewEth66PeersSendFullTransactions() {
+  public void onTransactionsAddedWithOnlyFewEth65PeersSendFullTransactions() {
     when(ethPeers.peerCount()).thenReturn(2);
     when(ethPeers.streamAvailablePeers())
-        .thenReturn(Stream.of(ethPeerWithEth66, ethPeerWithEth66_2));
+        .thenReturn(Stream.of(ethPeerWithEth65, ethPeerWithEth65_2));
 
     List<Transaction> txs = toTransactionList(setupTransactionPool(1, 1));
 
     txBroadcaster.onTransactionsAdded(txs);
 
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66, txs);
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66_2, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65_2, txs);
 
     sendTaskCapture.getAllValues().forEach(Runnable::run);
 
@@ -187,18 +186,18 @@ public class TransactionBroadcasterTest {
   }
 
   @Test
-  public void onTransactionsAddedWithOnlyEth66PeersSendFullTransactionsAndTransactionHashes() {
+  public void onTransactionsAddedWithOnlyEth65PeersSendFullTransactionsAndTransactionHashes() {
     when(ethPeers.peerCount()).thenReturn(3);
     when(ethPeers.streamAvailablePeers())
-        .thenReturn(Stream.of(ethPeerWithEth66, ethPeerWithEth66_2, ethPeerWithEth66_3));
+        .thenReturn(Stream.of(ethPeerWithEth65, ethPeerWithEth65_2, ethPeerWithEth65_3));
 
     List<Transaction> txs = toTransactionList(setupTransactionPool(1, 1));
 
     txBroadcaster.onTransactionsAdded(txs);
 
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66, txs);
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66_2, txs);
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66_3, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65_2, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65_3, txs);
 
     sendTaskCapture.getAllValues().forEach(Runnable::run);
 
@@ -208,19 +207,19 @@ public class TransactionBroadcasterTest {
 
   @Test
   public void onTransactionsAddedWithMixedPeersSendFullTransactionsAndTransactionHashes() {
-    List<EthPeer> eth66Peers = List.of(ethPeerWithEth66, ethPeerWithEth66_2);
+    List<EthPeer> eth65Peers = List.of(ethPeerWithEth65, ethPeerWithEth65_2);
 
     when(ethPeers.peerCount()).thenReturn(3);
     when(ethPeers.streamAvailablePeers())
-        .thenReturn(Stream.concat(eth66Peers.stream(), Stream.of(ethPeerNoEth66)));
+        .thenReturn(Stream.concat(eth65Peers.stream(), Stream.of(ethPeerNoEth65)));
 
     List<Transaction> txs = toTransactionList(setupTransactionPool(1, 1));
 
     txBroadcaster.onTransactionsAdded(txs);
 
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66, txs);
-    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth66_2, txs);
-    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth66, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65_2, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth65, txs);
 
     sendTaskCapture.getAllValues().forEach(Runnable::run);
 
@@ -228,13 +227,78 @@ public class TransactionBroadcasterTest {
     verify(transactionsMessageSender, times(2))
         .sendTransactionsToPeer(capPeerFullTransactions.capture());
     List<EthPeer> fullTransactionPeers = new ArrayList<>(capPeerFullTransactions.getAllValues());
-    assertThat(fullTransactionPeers.remove(ethPeerNoEth66)).isTrue();
-    assertThat(fullTransactionPeers).hasSize(1).first().isIn(eth66Peers);
+    assertThat(fullTransactionPeers.remove(ethPeerNoEth65)).isTrue();
+    assertThat(fullTransactionPeers).hasSize(1).first().isIn(eth65Peers);
 
     ArgumentCaptor<EthPeer> capPeerTransactionHashes = ArgumentCaptor.forClass(EthPeer.class);
     verify(newPooledTransactionHashesMessageSender)
         .sendTransactionHashesToPeer(capPeerTransactionHashes.capture());
-    assertThat(capPeerTransactionHashes.getValue()).isIn(eth66Peers);
+    assertThat(capPeerTransactionHashes.getValue()).isIn(eth65Peers);
+  }
+
+  @Test
+  public void
+      onTransactionsAddedWithMixedPeersAndHashOnlyBroadcastTransactionsSendTransactionHashes() {
+    List<EthPeer> eth65Peers = List.of(ethPeerWithEth65, ethPeerWithEth65_2);
+
+    when(ethPeers.peerCount()).thenReturn(3);
+    when(ethPeers.streamAvailablePeers())
+        .thenReturn(Stream.concat(eth65Peers.stream(), Stream.of(ethPeerNoEth65)));
+
+    List<Transaction> txs =
+        toTransactionList(setupTransactionPool(TransactionType.BLOB_TX_TYPE, 0, 1));
+
+    txBroadcaster.onTransactionsAdded(txs);
+
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65, txs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65_2, txs);
+    verifyNoTransactionAddedToPeerSendingQueue(ethPeerNoEth65);
+
+    sendTaskCapture.getAllValues().forEach(Runnable::run);
+
+    verify(transactionsMessageSender, times(0)).sendTransactionsToPeer(any());
+
+    ArgumentCaptor<EthPeer> capPeerOnlyHashes = ArgumentCaptor.forClass(EthPeer.class);
+    verify(newPooledTransactionHashesMessageSender, times(2))
+        .sendTransactionHashesToPeer(capPeerOnlyHashes.capture());
+    List<EthPeer> onlyHashPeers = new ArrayList<>(capPeerOnlyHashes.getAllValues());
+    assertThat(onlyHashPeers).hasSameElementsAs(eth65Peers);
+  }
+
+  @Test
+  public void onTransactionsAddedWithMixedPeersAndMixedBroadcastKind() {
+
+    List<EthPeer> eth65Peers = List.of(ethPeerWithEth65, ethPeerWithEth65_2);
+
+    when(ethPeers.peerCount()).thenReturn(3);
+    when(ethPeers.streamAvailablePeers())
+        .thenReturn(Stream.concat(eth65Peers.stream(), Stream.of(ethPeerNoEth65)));
+
+    // 1 full broadcast transaction type
+    // 1 hash only broadcast transaction type
+    List<Transaction> fullBroadcastTxs =
+        toTransactionList(setupTransactionPool(TransactionType.EIP1559, 0, 1));
+    List<Transaction> hashBroadcastTxs =
+        toTransactionList(setupTransactionPool(TransactionType.BLOB_TX_TYPE, 0, 1));
+
+    List<Transaction> mixedTxs = new ArrayList<>(fullBroadcastTxs);
+    mixedTxs.addAll(hashBroadcastTxs);
+
+    txBroadcaster.onTransactionsAdded(mixedTxs);
+
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65, mixedTxs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerWithEth65_2, mixedTxs);
+    verifyTransactionAddedToPeerSendingQueue(ethPeerNoEth65, fullBroadcastTxs);
+
+    sendTaskCapture.getAllValues().forEach(Runnable::run);
+
+    verify(transactionsMessageSender, times(1)).sendTransactionsToPeer(ethPeerNoEth65);
+
+    ArgumentCaptor<EthPeer> capPeerOnlyHashes = ArgumentCaptor.forClass(EthPeer.class);
+    verify(newPooledTransactionHashesMessageSender, times(2))
+        .sendTransactionHashesToPeer(capPeerOnlyHashes.capture());
+    List<EthPeer> onlyHashPeers = new ArrayList<>(capPeerOnlyHashes.getAllValues());
+    assertThat(onlyHashPeers).hasSameElementsAs(eth65Peers);
   }
 
   private void verifyNothingSent() {
@@ -252,9 +316,28 @@ public class TransactionBroadcasterTest {
     return pendingTxs;
   }
 
+  private Set<PendingTransaction> setupTransactionPool(
+      final TransactionType type, final int numLocalTransactions, final int numRemoteTransactions) {
+    Set<PendingTransaction> pendingTxs =
+        createPendingTransactionList(type, numLocalTransactions, true);
+    pendingTxs.addAll(createPendingTransactionList(type, numRemoteTransactions, false));
+
+    when(pendingTransactions.getPendingTransactions()).thenReturn(pendingTxs);
+
+    return pendingTxs;
+  }
+
   private Set<PendingTransaction> createPendingTransactionList(final int num, final boolean local) {
     return IntStream.range(0, num)
         .mapToObj(unused -> generator.transaction())
+        .map(tx -> new PendingTransaction(tx, local, Instant.now()))
+        .collect(Collectors.toSet());
+  }
+
+  private Set<PendingTransaction> createPendingTransactionList(
+      final TransactionType type, final int num, final boolean local) {
+    return IntStream.range(0, num)
+        .mapToObj(unused -> generator.transaction(type))
         .map(tx -> new PendingTransaction(tx, local, Instant.now()))
         .collect(Collectors.toSet());
   }
@@ -267,5 +350,10 @@ public class TransactionBroadcasterTest {
         .addToPeerSendQueue(eq(peer), trackedTransactions.capture());
     assertThat(trackedTransactions.getAllValues())
         .containsExactlyInAnyOrderElementsOf(transactions);
+  }
+
+  private void verifyNoTransactionAddedToPeerSendingQueue(final EthPeer peer) {
+
+    verify(transactionTracker, times(0)).addToPeerSendQueue(eq(peer), any());
   }
 }


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

When broadcasting transactions to peers, handle 4844 blob transactions in the following ways:

- For pre-eth/65 peers 4844 blob transactions are ignore are not sent
- For eth/65+ peers selected for full transaction body broadcast, a mixed approach is taken, and 2 messages are sent:
  - non-blob transactions are sent in full as before
  - for 4844 blob transactions only the hash is announced
- For eth/65+ peers selected for hash only announcements, same strategy as before, for all transactions (including 4844 blob ones) only the hashes are announced

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

implements #4821

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).