### PR TITLE
feat(publish-release): add workflow_dispatch trigger, gated to mainta…

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,10 +1,16 @@
 name: Publish Release
 
-run-name: "Publish Release ${{ github.event.release.name }}"
+run-name: "Publish Release ${{ github.event.release.name || inputs.tag }}"
 
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. 26.5.0). Use to re-fire publish jobs without toggling release draft state.'
+        required: true
+        type: string
 
 env:
   registry: docker.io
@@ -19,7 +25,7 @@ jobs:
       - name: Pre-process Release Name
         id: validate_release_version
         env:
-          RELEASE_VERSION: "${{ github.event.release.name }}"
+          RELEASE_VERSION: "${{ github.event.release.name || inputs.tag }}"
         run: |
           # strip all whitespace
           RELEASE_VERSION="${RELEASE_VERSION//[[:space:]]/}"
@@ -96,6 +102,12 @@ jobs:
   docker-promote:
     needs: [validate]
     runs-on: ubuntu-latest
+    # workflow_dispatch path is gated by the `production` environment in
+    # repo settings (branch policy: main, release-*). The release-event
+    # path is implicitly gated by who can publish a release, so it does
+    # not reference the environment (its github.ref is a tag, which
+    # would not match the branch policy).
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
       RC_VERSION: ${{ needs.validate.outputs.rc_version }}
@@ -194,6 +206,8 @@ jobs:
   artifactory:
     runs-on: ubuntu-latest
     needs: [validate]
+    # See docker-promote for why environment is conditional on event.
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'production' || '' }}
     env:
       RELEASE_VERSION: ${{ needs.validate.outputs.release_version }}
     steps:


### PR DESCRIPTION
…iners

Adds workflow_dispatch trigger so publish-release.yml can be re-fired without toggling release draft state. Needed because release-triggered workflows resolve the workflow file from the release tag's target sha, not the default branch -- bugs found and fixed on main after a release is cut do not apply to refires via draft toggle. workflow_dispatch runs from a chosen ref, so dispatching from main picks up fixes.

The release-event trigger path is implicitly gated by who can publish a release. workflow_dispatch otherwise allows anyone with write access to fire this workflow, which is too broad for a job that promotes docker `latest` tags and pushes Maven artifacts to Artifactory.

Restrict via gh api repos/.../collaborators/<actor>/permission lookup on dispatch only -- admin or maintain required. release-event path is unaffected.

Hit during the 26.5.0 publish recovery on 2026-05-12 -- after #10490 merged, the released-event refire still ran the pre-fix workflow because the release tag predated the fix.


## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


